### PR TITLE
use uv and python 3.12

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
 
     steps:
@@ -49,10 +49,15 @@ jobs:
     - uses: extractions/setup-just@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create and activate a virtual environment (Unix)
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        uv venv .venv
+        echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
+        echo "$PWD/.venv/bin" >> $GITHUB_PATH
     - name: Install Dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install .[test]
+        uv pip install .[test]
     - name: Run Tests
       run: just test
     - name: Upload Codecov


### PR DESCRIPTION
Updating default CI workflow to use python 3.12 and `uv`